### PR TITLE
remove field securityContext

### DIFF
--- a/Z-HSM/deployment/pkcs11-proxy-opencryptoki.yaml
+++ b/Z-HSM/deployment/pkcs11-proxy-opencryptoki.yaml
@@ -34,8 +34,6 @@ spec:
     spec:
       imagePullSecrets:
         - name: ibprepo-key-secret
-      securityContext:
-        privileged: true
       nodeSelector: 
         HSM: 'installed'
       containers:


### PR DESCRIPTION
kubectl apply -f pkcs11-proxy-opencryptoki.yaml -n registraccess

`error: error validating "pkcs11-proxy-opencryptoki.yaml": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext; `